### PR TITLE
fix 'validating compose.yaml: services.todo-app Additional property d…

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -19,7 +19,7 @@ services:
     ports:
       - 3000:3000
       - 35729:35729
-    develop:
+    x-develop:
       watch:
         - path: ./app/package.json
           action: rebuild


### PR DESCRIPTION
…evelop is not allowed' to make it compatible with docker compose version v2.21.0-desktop.1