### PR TITLE
Dockerfile, minor comment fix

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /usr/src/app
 
 # Download dependencies as a separate step to take advantage of Docker's caching.
 # Leverage a cache mount to /root/.npm to speed up subsequent builds.
-# Leverage a bind mounts to package.json and package-lock.json to avoid having to copy them into
+# Leverage a bind mounts to package.json and package-lock.json to avoid having to copy them
 # into this layer.
 RUN --mount=type=bind,source=package.json,target=package.json \
     --mount=type=bind,source=package-lock.json,target=package-lock.json \


### PR DESCRIPTION
Replacing

> Leverage a bind mounts to package.json and package-lock.json to avoid having to copy them **into**
> **into** this layer.

with

> Leverage a bind mounts to package.json and package-lock.json to avoid having to copy them
> into this layer.