### PR TITLE
fix(devops): Enable HMR/Watch by correcting CMD and NODE_ENV

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -9,7 +9,7 @@ ARG NODE_VERSION=19.5.0
 FROM node:${NODE_VERSION}-alpine
 
 # Use production node environment by default.
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 
 WORKDIR /usr/src/app
@@ -38,4 +38,4 @@ USER node
 EXPOSE 3000
 
 # Run the application in dev mode to use with Compose watch feature
-CMD npm run dev
+CMD ["nodemon", "server.js"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - todo-database
     environment:
-      NODE_ENV: production
+      NODE_ENV: development
     ports:
       - 3000:3000
       - 35729:35729


### PR DESCRIPTION
Updates the Dockerfile CMD to use 'nodemon server.js' and overrides NODE_ENV to 'development' in compose.yaml to enable the hot-reloading feature.