### PR TITLE
fix: evaluate created_at at todo insert time

### DIFF
--- a/app/models/Todo.js
+++ b/app/models/Todo.js
@@ -8,7 +8,7 @@ const TodoSchema = new Schema({
     },
     created_at: {
         type: Date,
-        default: Date.now()
+        default: Date.now
     }
 });
 


### PR DESCRIPTION
Todos were getting a shared created_at from schema load time (Date.now()). Use Date.now so each todo gets its insert timestamp.